### PR TITLE
Version management of gems with bundler - first stab

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+# A sample Gemfile
+source "https://rubygems.org"
+
+gem "vagrant", "1.0.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,29 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    archive-tar-minitar (0.5.2)
+    childprocess (0.3.1)
+      ffi (~> 1.0.6)
+    erubis (2.7.0)
+    ffi (1.0.11)
+    i18n (0.6.0)
+    json (1.5.4)
+    log4r (1.1.10)
+    net-scp (1.0.4)
+      net-ssh (>= 1.99.1)
+    net-ssh (2.2.2)
+    vagrant (1.0.1)
+      archive-tar-minitar (= 0.5.2)
+      childprocess (~> 0.3.1)
+      erubis (~> 2.7.0)
+      i18n (~> 0.6.0)
+      json (~> 1.5.1)
+      log4r (~> 1.1.9)
+      net-scp (~> 1.0.4)
+      net-ssh (~> 2.2.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  vagrant (= 1.0.1)


### PR DESCRIPTION
Hi,

to automate what is in version.txt it seems handy to use bundler. Take the files here (Gemfile and Gemfile.lock) and run 'bundle install'. You should now get vagrant 1.0.1 . A full list of dependent versions for vagrant 1.0.1 you can see in Gemfile.lock. (the Gemfile only specifies vagrant 1.0.1 at the moment. I'll add rake etc. later when bundler also works in jenkins).

Cheers,

Willem
